### PR TITLE
Use path.join(__dirname.. ) to fix relative path.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,9 +5,8 @@ const debug = require('debug')('client')
 const Transport = require('./transport.js')
 
 const protobuf = require('protobufjs')
-
-//TODO may not be suitable for production
-const root = protobuf.loadSync('./doc/apollo.proto')
+const path = require('path')
+const root = protobuf.loadSync(path.join(__dirname, '../doc/apollo.proto'))
 
 function type(typeName) {
   return root.lookup(typeName)


### PR DESCRIPTION
Fix relative path to proto file that is used by client.js.